### PR TITLE
Implement basic mood mode UI

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -12,6 +12,16 @@ async def get_recommendations():
     return {"recommendations": []}
 
 
+class MoodRequest(BaseModel):
+    mood: str
+
+
+@router.post("/recommendations")
+async def post_recommendations(payload: MoodRequest):
+    """Accept a mood string and return placeholder recommendations."""
+    return {"recommendations": [], "mood": payload.mood}
+
+
 class AuthRequest(BaseModel):
     email: str
     password: str

--- a/frontend/components/Nav.tsx
+++ b/frontend/components/Nav.tsx
@@ -5,7 +5,8 @@ export default function Nav() {
     <nav style={{ marginBottom: '1rem' }}>
       <Link href="/">Home</Link> |{' '}
       <Link href="/mood">Mood</Link> |{' '}
-      <Link href="/quiz">Quiz</Link>
+      <Link href="/quiz">Quiz</Link> |{' '}
+      <Link href="/results">Results</Link>
     </nav>
   )
 }

--- a/frontend/pages/mood.tsx
+++ b/frontend/pages/mood.tsx
@@ -1,11 +1,77 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
 import Nav from '../components/Nav'
 
+const PRESET_MOODS = [
+  { label: 'Happy', emoji: '😄' },
+  { label: 'Stressed', emoji: '😫' },
+  { label: 'Nostalgic', emoji: '📻' },
+  { label: 'Adventurous', emoji: '🧗' },
+  { label: 'Romantic', emoji: '💕' },
+  { label: 'Bored', emoji: '😐' },
+]
+
 export default function Mood() {
+  const [customMood, setCustomMood] = useState('')
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+
+  async function submitMood(mood: string) {
+    setLoading(true)
+    try {
+      await fetch('/api/recommendations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mood }),
+      })
+    } catch (err) {
+      console.error(err)
+    }
+    setLoading(false)
+    router.push(`/results?mood=${encodeURIComponent(mood)}`)
+  }
+
+  if (loading) {
+    return (
+      <div>
+        <Nav />
+        <p>Loading…</p>
+      </div>
+    )
+  }
+
   return (
     <div>
       <Nav />
-      <h1>Mood Page</h1>
-      <p>Placeholder for mood-based recommendations.</p>
+      <h1>Select Your Mood</h1>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+        {PRESET_MOODS.map((m) => (
+          <button
+            key={m.label}
+            onClick={() => submitMood(m.label)}
+            title={m.label}
+            style={{ padding: '0.5rem 1rem', fontSize: '1rem' }}
+          >
+            <span style={{ marginRight: '0.25rem' }}>{m.emoji}</span>
+            {m.label}
+          </button>
+        ))}
+      </div>
+      <div style={{ marginTop: '1rem' }}>
+        <input
+          type="text"
+          placeholder="Describe your mood…"
+          value={customMood}
+          onChange={(e) => setCustomMood(e.target.value)}
+          style={{ padding: '0.5rem', width: '60%' }}
+        />
+        <button
+          onClick={() => customMood && submitMood(customMood)}
+          style={{ marginLeft: '0.5rem', padding: '0.5rem 1rem' }}
+        >
+          Let’s Go
+        </button>
+      </div>
     </div>
   )
 }

--- a/frontend/pages/results.tsx
+++ b/frontend/pages/results.tsx
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router'
+import Nav from '../components/Nav'
+
+export default function Results() {
+  const router = useRouter()
+  const { mood } = router.query
+
+  return (
+    <div>
+      <Nav />
+      <h1>Recommendations</h1>
+      {mood && <p>Mood: {mood}</p>}
+      <p>Placeholder for recommendations.</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement interactive Mood Mode page
- add placeholder results page
- update navigation links
- accept POST /api/recommendations with mood string

## Testing
- `npm run lint` *(fails: `next: not found`)*