### PR TITLE
Implement Supabase interaction tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ client ID and secret in `.env` to enable these features.
 =======
 Database schema and RLS policies are defined in `docs/db/schema.sql`.
 
+The frontend stores user interactions ("Seen" or "Loved") in Supabase using the
+`user_content` table. Logged in users will see their saved status on the
+recommendations page.
+

--- a/frontend/context/UserContentContext.tsx
+++ b/frontend/context/UserContentContext.tsx
@@ -1,0 +1,83 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+import { supabase } from '../utils/supabaseClient'
+import { useAuth } from './AuthContext'
+
+export type ContentStatus = 'seen' | 'loved'
+
+interface UserContentContextType {
+  statuses: Record<string, ContentStatus>
+  loading: boolean
+  markContent: (
+    contentId: string,
+    contentType: string,
+    status: ContentStatus
+  ) => Promise<{ error: string | null }>
+}
+
+const UserContentContext = createContext<UserContentContextType>({
+  statuses: {},
+  loading: true,
+  markContent: async () => ({ error: null })
+})
+
+export function UserContentProvider({ children }: { children: React.ReactNode }) {
+  const { user } = useAuth()
+  const [statuses, setStatuses] = useState<Record<string, ContentStatus>>({})
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      if (!user) {
+        setStatuses({})
+        setLoading(false)
+        return
+      }
+      setLoading(true)
+      const { data, error } = await supabase
+        .from('user_content')
+        .select('content_id, status')
+        .eq('id', user.id)
+      if (!error && data) {
+        const map: Record<string, ContentStatus> = {}
+        for (const row of data) {
+          map[row.content_id] = row.status as ContentStatus
+        }
+        setStatuses(map)
+      } else if (error) {
+        console.error('Failed to load content statuses', error)
+      }
+      setLoading(false)
+    }
+    load()
+  }, [user])
+
+  const markContent = async (
+    contentId: string,
+    contentType: string,
+    status: ContentStatus
+  ) => {
+    if (!user) return { error: 'Not authenticated' }
+    const previous = statuses[contentId]
+    setStatuses((prev) => ({ ...prev, [contentId]: status }))
+    const { error } = await supabase
+      .from('user_content')
+      .upsert(
+        { id: user.id, content_id: contentId, content_type: contentType, status },
+        { onConflict: 'id,content_id' }
+      )
+    if (error) {
+      console.error('Failed to update content', error)
+      setStatuses((prev) => ({ ...prev, [contentId]: previous }))
+      return { error: error.message }
+    }
+    return { error: null }
+  }
+
+  return (
+    <UserContentContext.Provider value={{ statuses, loading, markContent }}>
+      {children}
+    </UserContentContext.Provider>
+  )
+}
+
+export const useUserContent = () => useContext(UserContentContext)

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,11 +1,14 @@
 import type { AppProps } from 'next/app'
 import '../styles/globals.css'
 import { AuthProvider } from '../context/AuthContext'
+import { UserContentProvider } from '../context/UserContentContext'
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <AuthProvider>
-      <Component {...pageProps} />
+      <UserContentProvider>
+        <Component {...pageProps} />
+      </UserContentProvider>
     </AuthProvider>
   )
 }

--- a/frontend/pages/results.tsx
+++ b/frontend/pages/results.tsx
@@ -1,16 +1,57 @@
 import { useRouter } from 'next/router'
 import Nav from '../components/Nav'
+import { useUserContent } from '../context/UserContentContext'
+import { useAuth } from '../context/AuthContext'
 
 export default function Results() {
   const router = useRouter()
   const { mood } = router.query
+  const { user } = useAuth()
+  const { statuses, markContent } = useUserContent()
+
+  const content = [
+    { id: 'movie1', title: 'Back to the Future', type: 'movie' },
+    { id: 'game1', title: 'Stardew Valley', type: 'game' },
+    { id: 'movie2', title: 'The Breakfast Club', type: 'movie' }
+  ]
 
   return (
     <div>
       <Nav />
       <h1>Recommendations</h1>
       {mood && <p>Mood: {mood}</p>}
-      <p>Placeholder for recommendations.</p>
+      <ul>
+        {content.map((item) => (
+          <li key={item.id} style={{ marginBottom: '0.5rem' }}>
+            <strong>{item.title}</strong> ({item.type})
+            <div>
+              <button
+                onClick={() => markContent(item.id, item.type, 'seen')}
+                style={{
+                  fontWeight: statuses[item.id] === 'seen' ? 'bold' : 'normal'
+                }}
+              >
+                Seen
+              </button>
+              <button
+                onClick={() => markContent(item.id, item.type, 'loved')}
+                style={{
+                  marginLeft: '0.5rem',
+                  fontWeight: statuses[item.id] === 'loved' ? 'bold' : 'normal'
+                }}
+              >
+                Loved
+              </button>
+              {statuses[item.id] && (
+                <span style={{ marginLeft: '0.5rem' }}>
+                  Current: {statuses[item.id]}
+                </span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+      {!user && <p>Login to save your interactions.</p>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- introduce `UserContentProvider` for storing user interactions
- wrap app with new provider
- update results page with Seen/Loved buttons that persist to Supabase
- document new feature in README

## Testing
- `pytest -q` *(fails: command not found)*